### PR TITLE
enable window resize breakpoint update within doc ready

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "jquery-breakpoints",
 	"main": "jquery-breakpoints.js",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"ignore": [
 		"**/.*"
 	],

--- a/jquery-breakpoints.js
+++ b/jquery-breakpoints.js
@@ -21,11 +21,11 @@
 		// Initial breakpoint on document ready
 		$( document ).ready( function() {
 			getBreakpoint();
-		} );
-		
-		// Check breakpoint on window resize
-		$( window ).resize( function() {
-			getBreakpoint();
+
+			// Check breakpoint on window resize
+			$( window ).resize( function() {
+				getBreakpoint();
+			} );
 		} );
 
 		// Checks the breakpoints and dispatches events


### PR DESCRIPTION
Moving `$( window ).resize()` method within `$( document ).ready()`.
