### PR TITLE
Switching to $(window).outerWidth()

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "jquery-breakpoints",
 	"main": "jquery-breakpoints.js",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"ignore": [
 		"**/.*"
 	],

--- a/jquery-breakpoints.js
+++ b/jquery-breakpoints.js
@@ -37,7 +37,7 @@
 
 			// Compare sorted breakpoint list
 			$.each( settings.breakpoints, function( index, breakpoint ) {
-				var width = $( window ).width();
+				var width = $( window ).outerWidth();
 
 				// Break on first breakpoint larger than window width
 				if ( breakpoint.breakpointWidth >= width ) {


### PR DESCRIPTION
In jQuery 3, $(window).outerWidth() finally started providing full width of the window, including scrollbars. That makes it possible to easily sync CSS media queries-based breakpoints to the ones which are jQuery-based (breakpoints set by CSS media queries switch at the same time as jQuery-based).
